### PR TITLE
Update to manage different timers for system ticks (part 1/2)

### DIFF
--- a/lib/miniAVRfreeRTOS/FreeRTOSBoardDefs.h
+++ b/lib/miniAVRfreeRTOS/FreeRTOSBoardDefs.h
@@ -48,10 +48,10 @@ extern "C" {
 #include <avr/io.h>
 #include <avr/wdt.h>
 
-// System Tick - Scheduler timer
-// Use the Watchdog timer, and choose the rate at which scheduler interrupts will occur.
+// System Tick  - Scheduler timer
+// Prefer to use the Watchdog timer, but also Timer 0, 1, or 3 are ok.
 
-#define portUSE_WDTO            WDTO_15MS    // portUSE_WDTO to use the Watchdog Timer for xTaskIncrementTick
+// #define portUSE_WDTO            WDTO_15MS                        // portUSE_WDTO to use the Watchdog Timer for xTaskIncrementTick
 
 /* Watchdog period options:     WDTO_15MS
                                 WDTO_30MS
@@ -60,11 +60,33 @@ extern "C" {
                                 WDTO_250MS
                                 WDTO_500MS
 */
+
+//  #define portUSE_TIMER0                                          // portUSE_TIMER0 to use 8 bit Timer0 for xTaskIncrementTick
+    #define portUSE_TIMER1                                          // portUSE_TIMER1 to use 16 bit Timer1 for xTaskIncrementTick
+//  #define portUSE_TIMER2                                          // portUSE_TIMER2 to use 8 bit Timer2 using 32,768Hz for xTaskIncrementTick
+//  #define portUSE_TIMER3                                          // portUSE_TIMER3 to use 16 bit Timer3 for xTaskIncrementTick
+
+// Use Timer 2 for a Real Time Clock, if you have a 32kHz watch crystal attached.
+//  #define portUSE_TIMER2_RTC                                      // portUSE_TIMER2_RTC to use 8 bit RTC Timer2 for system_tick (not xTaskIncrementTick)
+
+
+#if defined (portUSE_WDTO)
 //    xxx Watchdog Timer is 128kHz nominal, but 120 kHz at 5V DC and 25 degrees is actually more accurate, from data sheet.
-#define configTICK_RATE_HZ  ( (TickType_t)( (uint32_t)128000 >> (portUSE_WDTO + 11) ) )  // 2^11 = 2048 WDT scaler for 128kHz Timer
+#define configTICK_RATE_HZ             ( (TickType_t)( (uint32_t)128000 >> (portUSE_WDTO + 11) ) )  // 2^11 = 2048 WDT Scale-factor
+
+#elif defined (portUSE_TIMER0) || defined (portUSE_TIMER1) || defined (portUSE_TIMER3)
+#define configTICK_RATE_HZ            ( (TickType_t) 200 )          // Use 1000Hz to get mSec timing using Timer1 or Timer3.
+
+#elif defined( portUSE_TIMER2 ) && !defined( portUSE_TIMER2_RTC )
+#define configTICK_RATE_HZ            ( (TickType_t) 128 )          // MINIMUM for TIMER2 is 128 Hz because of fixed scale factor.
 
 #ifdef __cplusplus
 }
 #endif
 
 #endif // freeRTOSBoardDefs_h
+
+
+
+
+


### PR DESCRIPTION
The file "FreeRTOSBoardDefs.h" is modified.
The frequency of the tick is here defined. 
I chose randomly Timer1 @ 200Hz ; but feel free to use Timer1 @ 1000Hz to have ms-based tik.
In the lib, the constant "portTICK_PERIOD_MS" is adapted in <portmacro.h>