### PR TITLE
Write total_operating_time and cycles_numbers to EEPROM every 5 min #7

### DIFF
--- a/src/core/debug.c
+++ b/src/core/debug.c
@@ -18,7 +18,7 @@
 
 void debug_print_FromISR(const char *fmt, ...)
 {
-    char buffer[128];
+    char buffer[32];
 
     va_list args;
     va_start(args, fmt);

--- a/src/core/eeprom.c
+++ b/src/core/eeprom.c
@@ -1,0 +1,101 @@
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <avr/eeprom.h>
+#include <avr/interrupt.h>
+
+#include "FreeRTOS.h"
+#include "task.h"
+
+#include "core/debug.h"
+#include "core/system.h"
+#include "core/eeprom.h"
+
+#define EEPROM_INIT_MAGIC_NUMBER 0xb0dfe7a1
+
+#define EEPROM_ADDR_MAGIC_NUMBER ((uint32_t *) 0x0)
+#define EEPROM_ADDR_POS_DATA ((uint32_t *) 0x4)
+#define EEPROM_MIN_POS_DATA ((uint32_t *) 0x8)
+#define EEPROM_SIZE_DATA 2
+#define EEPROM_MAX_POS_DATA (EEPROM_MIN_POS_DATA + 1*EEPROM_SIZE_DATA)
+// in seconds
+#define EEPROM_OFFSET_TOT_TIME 0
+#define EEPROM_OFFSET_TOT_CYCLES 1
+
+#define DEBUG_EEPROM 1
+#if DEBUG_EEPROM
+#define DEBUG_PRINT debug_print
+#else
+#define DEBUG_PRINT fake_debug_print
+#endif
+
+// For EEPROM
+uint32_t total_operating_time;
+uint32_t *eeprom_offset;
+
+static TimeOut_t timeOutBoundedWait;
+static TickType_t boundedWaitTime;
+
+static void eeprom_write_data() {
+    // order is important !
+    cli();
+    uint32_t cyc = GET_CYCLE_COUNT();
+    sei();
+    eeprom_write_dword(eeprom_offset + EEPROM_OFFSET_TOT_TIME, total_operating_time);
+    eeprom_write_dword(eeprom_offset + EEPROM_OFFSET_TOT_CYCLES, cyc);
+    eeprom_write_dword(EEPROM_ADDR_POS_DATA, (uint16_t) eeprom_offset);
+}
+
+static void eeprom_inc_offset() {
+    eeprom_offset += EEPROM_SIZE_DATA;
+    if (eeprom_offset > EEPROM_MAX_POS_DATA) {
+        eeprom_offset = EEPROM_MIN_POS_DATA;
+    }
+}
+
+static void reset_wait_time() {
+    vTaskSetTimeOutState(&timeOutBoundedWait);
+    boundedWaitTime = pdMS_TO_TICKS(WRITE_EEPROM_PERIOD_MS);
+}
+
+bool init_eeprom() {
+    // Check if EEPROM has been initialized
+    if (EEPROM_INIT_MAGIC_NUMBER == eeprom_read_dword(EEPROM_ADDR_MAGIC_NUMBER)) {
+        // Not first boot, read EEPROM content
+        eeprom_offset = (uint32_t *) (uint16_t) eeprom_read_dword(EEPROM_ADDR_POS_DATA);
+        total_operating_time = eeprom_read_dword(eeprom_offset + EEPROM_OFFSET_TOT_TIME);
+        SET_CYCLE_COUNT(eeprom_read_dword(eeprom_offset + EEPROM_OFFSET_TOT_CYCLES));
+        DEBUG_PRINT("[MAIN] EEPROM, tot: %u\r\n", total_operating_time);
+        DEBUG_PRINT("[MAIN] EEPROM, cn: %u\r\n", GET_CYCLE_COUNT());
+        return false;
+    }
+    else {
+        DEBUG_PRINT("[EEPROM] First boot ever!\r\n");
+        total_operating_time = 0;
+        SET_CYCLE_COUNT(0);
+        eeprom_offset = EEPROM_MIN_POS_DATA;
+        // order of initialization is important !
+        eeprom_write_data();
+        eeprom_write_dword(EEPROM_ADDR_MAGIC_NUMBER, EEPROM_INIT_MAGIC_NUMBER);
+        return true;
+    }
+}
+
+void eepromTask(void *pvParameters) {
+    reset_wait_time();
+    while (1) {
+        if (xTaskCheckForTimeOut(&timeOutBoundedWait, &boundedWaitTime)) {
+            reset_wait_time();
+
+            total_operating_time += WRITE_EEPROM_PERIOD_MS/1000L;
+
+            DEBUG_PRINT("[EEPROM], tot: %u\r\n", total_operating_time);
+            DEBUG_PRINT("[EEPROM], cn: %u\r\n", GET_CYCLE_COUNT());
+
+            eeprom_inc_offset();
+            eeprom_write_data();
+        }
+        uint32_t notif_recv;
+        xTaskNotifyWait(0x0,ALL_NOTIF_BITS,&notif_recv,boundedWaitTime);
+    }
+}

--- a/src/core/eeprom.h
+++ b/src/core/eeprom.h
@@ -1,0 +1,30 @@
+/** EEPROM management
+ */
+#ifndef EEPROM_H_
+#define EEPROM_H_
+
+#define WRITE_EEPROM_PERIOD_MS 300 * 1000L // Try 5 * 1000L for Testing purpose
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/** @init_eeprom Initialize the EEPROM task
+ *
+ * @return true if this is the first boot, false otherwise
+ */
+bool init_eeprom();
+
+/** @eepromTask EEPROM writing of running time and number of cycles
+ */
+void eepromTask(void *pvParameters);
+
+// TODO implement this
+/** @GET_CYCLE_COUNT Function that returns the motor cycle count
+ */
+#define GET_CYCLE_COUNT() (0)
+
+// TODO implement this
+/** @SET_CYCLE_COUNT Function that sets the current cycle count
+ */
+#define SET_CYCLE_COUNT(x) (x)
+#endif // EEPROM_H_

--- a/src/core/main_task.c
+++ b/src/core/main_task.c
@@ -47,6 +47,7 @@ static void set_critical_failure(CriticalFailureCause_t cause);
 #define SIM_MOTOR 0             // "simulate" motor to debug the rest
 #define ALARM_CHECK 1           // active/deactivate alarm check for debug
 #define CALIB_ERROR_CHECK 1     // active/deactivate calib error check during calib for debug
+
 #define POWER_AUX_CHECK 0       // active/deactivate power aux check for debug
 #define POWER_MAIN_CHECK 1      // active/deactivate power main check for debug
 #define DOOR_CHECK 1            // active/deactivate door check for debug
@@ -394,7 +395,6 @@ void MainTask(void *pvParameters)
         /*
          * 14. EEPROM total operating writing
          */
-
         // TODO
 
         /*

--- a/src/core/main_task.h
+++ b/src/core/main_task.h
@@ -73,4 +73,6 @@ uint8_t stoppedOrRunning();
 /* check if volume is within +- 10% of target volume */
 void check_volume(uint32_t actual_vol);
 
+void incrementCyclesNumber();
+
 #endif // MAINTASK_H_

--- a/src/core/ring_buf.h
+++ b/src/core/ring_buf.h
@@ -6,7 +6,7 @@
 #include <stdbool.h>
 
 // maximum buffer size
-#define RBUF_SIZE 512
+#define RBUF_SIZE 256
 
 // buffer structure
 typedef struct ring_buf_s

--- a/src/core/system.h
+++ b/src/core/system.h
@@ -14,10 +14,10 @@
 
 extern TaskHandle_t mainTaskHandle;
 extern TaskHandle_t motorControlTaskHandle;
+extern TaskHandle_t buzzerTaskHandle;
 extern TaskHandle_t lcdDisplayTaskHandle;
 extern TaskHandle_t analogReadTaskHandle;
-extern TaskHandle_t buzzerTaskHandle;
-extern TaskHandle_t sfm3000TaskHandle;
+extern TaskHandle_t eepromTaskHandle;
 
 typedef enum {
     welcome,

--- a/src/main.c
+++ b/src/main.c
@@ -14,6 +14,7 @@
 #include "core/main_task.h"
 #include "core/analog_read.h"
 #include "core/volume.h"
+#include "core/eeprom.h"
 
 #include "hal/io.h"
 #include "hal/pins.h"
@@ -25,10 +26,10 @@
 
 TaskHandle_t mainTaskHandle;
 TaskHandle_t motorControlTaskHandle;
+TaskHandle_t buzzerTaskHandle;
 TaskHandle_t lcdDisplayTaskHandle;
 TaskHandle_t analogReadTaskHandle;
-TaskHandle_t buzzerTaskHandle;
-TaskHandle_t sfm3000TaskHandle;
+TaskHandle_t eepromTaskHandle;
 
 void initHardware(void)
 {
@@ -87,13 +88,12 @@ int main(void)
     initHardware();
 
     // Create the different tasks
-    xTaskCreate(MotorControlTask,  (const char *) "MotorControlTask",  512, NULL, 10, &motorControlTaskHandle);
-    xTaskCreate(MainTask,  (const char *) "MainTask",  512, NULL, 12, &mainTaskHandle);
-    xTaskCreate(LCDDisplayTask,    (const char *) "LCDDisplayTask",    512,  NULL,  3, &lcdDisplayTaskHandle);
-    xTaskCreate(BuzzerTask,        (const char *) "BuzzerTask",        128,  NULL,  4, &buzzerTaskHandle);
-    //xTaskCreate(LEDTask,           (const char *) "LEDTask",           128, NULL,  1, NULL);
-    //xTaskCreate(ReadIOTask,        (const char *) "ReadIOTask",        128, NULL,  1, NULL);
-    xTaskCreate(AnalogReadTask,    (const char *) "ReadAnalogTask",    128, NULL,  1, &analogReadTaskHandle);
+    xTaskCreate(MainTask, "MainTask", 512, NULL, 12, &mainTaskHandle);
+    xTaskCreate(MotorControlTask, "MotorControl", 512, NULL, 10, &motorControlTaskHandle);
+    xTaskCreate(BuzzerTask, "Buzzer", 128, NULL, 4, &buzzerTaskHandle);
+    xTaskCreate(LCDDisplayTask, "LCDDisplay", 512, NULL, 3, &lcdDisplayTaskHandle);
+    xTaskCreate(AnalogReadTask, "ReadAnalog", 128, NULL, 2, &analogReadTaskHandle);
+    xTaskCreate(eepromTask, "EEPROM", 128, NULL, 1, &eepromTaskHandle);
 
     // Run the OS
     vTaskStartScheduler();


### PR DESCRIPTION
To test it, it is easier to change WRITE_EEPROM_PERIOD_MS from "3000 * 1000L" to "5 * 1000L".

incrementCyclesNumber() need to be called from another task (and the current call need to be removed [there is a FIXME]).